### PR TITLE
Fix Documentation Workflow

### DIFF
--- a/.github/workflows/Doc.yml
+++ b/.github/workflows/Doc.yml
@@ -1,37 +1,37 @@
 name: Doc
 
-# Temporarily disabled
 on:
-  workflow_dispatch:  # Only manual triggers for now
-  # push:
-  #   branches:
-  #     - "main"
-  # pull_request:
-  #   branches:
-  #     - "main"
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
 
 jobs:
   unix:
     runs-on: ubuntu-22.04
-    name: Doc (Python ${{ matrix.python-version }})
+    name: Doc
     strategy:
       fail-fast: false
       matrix:
         include:
           - python-version: "3.12"
+            openmm-version: "8.3"
+            compiler-version: "14.3"
 
     steps:
       - name: "Check out"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: "Update the conda enviroment file"
         uses: cschleiden/replace-tokens@v1
         with:
           tokenPrefix: '@'
           tokenSuffix: '@'
-          files: devtools/conda-envs/build-ubuntu-22.04.yml
+          files: devtools/conda-envs/build-doc.yml
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         name: "Install dependencies with conda"
         with:
           activate-environment: build
@@ -47,9 +47,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DPLUGIN_BUILD_CUDA_LIB=OFF
+          cmake .. -DOPENMM_BUILD_PLUGIN_CUDA=OFF -DOPENMM_BUILD_PLUGIN_OPENCL=OFF
 
       - name: "Build"
         shell: bash -l {0}
@@ -57,6 +55,11 @@ jobs:
           cd build
           make -j2 install
           make -j2 PythonInstall
+
+      - name: "List plugins"
+        shell: bash -l {0}
+        run: |
+          python -c "import openmm as mm; print('---Loaded---', *mm.pluginLoadedLibNames, '---Failed---', *mm.Platform.getPluginLoadFailures(), sep='\n')"
 
       - name: Build Documentation
         shell: bash -l {0}

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -58,10 +58,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCUDA_TOOLKIT_ROOT_DIR=${CUDA_PATH} \
-            -DCUDA_CUDA_LIBRARY=${CUDA_PATH}/lib64/stubs
+          cmake ..
 
       - name: "Build"
         shell: bash -l {0}

--- a/devtools/conda-envs/build-doc.yml
+++ b/devtools/conda-envs/build-doc.yml
@@ -3,15 +3,16 @@ channels:
   - conda-forge
 dependencies:
   - cmake
-  - compilers
-  - ocl-icd-system
+  - gxx_linux-64 @COMPILER_VERSION@
   - make
+  - ocl-icd-system
   - openmm @OPENMM_VERSION@
   - pip >=22.2
-  - pocl
   - pytest
   - python
+  - doxygen
   - swig =4.0
+  - sysroot_linux-64 2.17
   - numpy
 
   # Docs depends


### PR DESCRIPTION
# Fix Documentation Workflow

This PR fixes and re-enables the documentation workflow.

## Key Changes

### 1. Re-enable Documentation Workflow
- Enable automatic triggers for main branch
- Update GitHub Actions dependencies to latest versions:
  - actions/checkout@v5
  - conda-incubator/setup-miniconda@v3

### 2. Improve Build Environment
- Use dedicated build-doc.yml environment file
- Add specific GCC version (14.3) for better reproducibility
- Add doxygen package explicitly
- Remove unnecessary CUDA/OpenCL dependencies
- Add sysroot for Linux builds

### 3. Simplify and Improve Build Process
- Simplify CMake configuration
- Disable CUDA and OpenCL plugins for docs build
- Add plugin listing step for better debugging
- Clean up job naming

### 4. Code Organization
- Better organization of conda dependencies
- Remove redundant CMake flags in Linux workflow
- Improve workflow readability

## Testing
The workflow has been tested to ensure:
- Documentation builds correctly
- All necessary dependencies are available
- Build process is streamlined for docs-only builds